### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,12 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev
 
@@ -21,11 +25,11 @@ script:
   - vendor/bin/phpunit --verbose --coverage-text --coverage-clover=coverage.xml
 
 after_script:
-  - vendor/bin/test-reporter --coverage-report coverage.xml
+  -  ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-addons:
-  code_climate:
-    repo_token: 02e57319943d31e22263c9ecb87c5c661837c6906ce357502e54da3115b32352
+env:
+  global:
+    - CC_TEST_REPORTER_ID=02e57319943d31e22263c9ecb87c5c661837c6906ce357502e54da3115b32352

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,11 @@
     },
     "require-dev": {
         "composer/composer": "^1.2",
-        "phpunit/phpunit": ">=4.8 <6.0",
-        "codeclimate/php-test-reporter": "dev-master"
+        "phpunit/phpunit": "^4.8.36 <6.0"
     },
     "autoload": {
-        "psr-0": {
-            "NodejsPhpFallback\\": "src/"
+        "psr-4": {
+            "NodejsPhpFallback\\": "src/NodejsPhpFallback"
         }
     }
 }

--- a/tests/StylusTest.php
+++ b/tests/StylusTest.php
@@ -2,6 +2,7 @@
 
 use NodejsPhpFallback\NodejsPhpFallback;
 use NodejsPhpFallback\Stylus;
+use PHPUnit\Framework\TestCase;
 
 class StylusWithoutNode extends Stylus
 {
@@ -12,7 +13,7 @@ class StylusWithoutNode extends Stylus
     }
 }
 
-class StylusTest extends PHPUnit_Framework_TestCase
+class StylusTest extends TestCase
 {
     public function testGetStylusFromRaw()
     {


### PR DESCRIPTION
# Changed log
- Add `php-7.4` version test during Travis CI build.
- To be compatible with future latest `PHPUnit` version, defining the `^4.8.36` version on `composer.json`.
And using the `PHPUnit\Framework\TestCase` namespace.
- The `test-reporter` PHP package is deprecated. Using the `test-reporter` script instead.
- The `PSR-o` autoloading is deprecated. Using the `PSR-4` autoloading instead.